### PR TITLE
Changed title_slug to titleSlug to handle leetcode change

### DIFF
--- a/app/services/leet_code_service.rb
+++ b/app/services/leet_code_service.rb
@@ -21,7 +21,7 @@ class LeetCodeService < SiteService
     contest_info = {}
 
     contest_info[:name] = contest['title']
-    contest_info[:url] = "https://leetcode.com/contest/#{contest['title_slug']}"
+    contest_info[:url] = "https://leetcode.com/contest/#{contest['titleSlug']}"
     contest_info[:duration] = contest['duration'].to_i
 
     start_time = DateTime.strptime contest['startTime'].to_s, '%s'


### PR DESCRIPTION
#63 
#### Missing Leetcode contest slug in https://kontests.net/api/v1/all

![image](https://user-images.githubusercontent.com/65885903/176652063-5db73bf6-5404-439a-aa20-225ff87a012a.png)


#### Leetcode api has contest slug within json object variable name 'titleSlug'

![image](https://user-images.githubusercontent.com/65885903/176652250-0d9ed341-ff59-44a8-b877-712de4f06129.png)

#### Replaced 'title_slug' to 'titleSlug' to support the change

 
